### PR TITLE
Fix key in usa-president-map-type.js for Mangum spelling

### DIFF
--- a/src/model/map-types/usa-president-map-type.js
+++ b/src/model/map-types/usa-president-map-type.js
@@ -1187,7 +1187,7 @@ var USAPresidentMapType = new MapType(
       1824: {"Adams":DemocraticRepublicanParty.getID(), "Jackson":Independent1824AJParty.getID(), "Crawford":Independent1824WCParty.getID(), "Clay":Independent1824HCParty.getID(), "Other":IndependentGenericParty.getID()},
       1828: {"Jackson":DemocraticParty.getID(), "Adams":NationalRepublicanParty.getID(), "Other":IndependentGenericParty.getID()},
       1832: {"Jackson":DemocraticParty.getID(), "Clay":NationalRepublicanParty.getID(), "Wirt":Independent1832WWParty.getID(), "Floyd":Independent1832JFParty.getID(), "Other":IndependentGenericParty.getID()},
-      1836: {"Van Buren":DemocraticParty.getID(), "Harrison":WhigParty.getID(), "White":Independent1836HWParty.getID(), "Webster":Independent1836DWParty.getID(), "Magnum":Independent1836WMParty.getID(), "Other":IndependentGenericParty.getID()},
+      1836: {"Van Buren":DemocraticParty.getID(), "Harrison":WhigParty.getID(), "White":Independent1836HWParty.getID(), "Webster":Independent1836DWParty.getID(), "Mangum":Independent1836WMParty.getID(), "Other":IndependentGenericParty.getID()},
       1840: {"Van Buren":DemocraticParty.getID(), "Harrison":WhigParty.getID(), "Other":IndependentGenericParty.getID()},
       1844: {"Polk":DemocraticParty.getID(), "Clay":WhigParty.getID(), "Birney":Independent1844JBParty.getID(), "Other":IndependentGenericParty.getID()},
       1848: {"Cass":DemocraticParty.getID(), "Taylor":WhigParty.getID(), "Van Buren":FreeSoilParty.getID(), "Other":IndependentGenericParty.getID()},


### PR DESCRIPTION
Mangums' name was being displayed as "Independent" because a key in the usa-president-map-type.js had his name spelled wrong. Now it can get his correct data.